### PR TITLE
Add: Performance bar graph for average load time by browser

### DIFF
--- a/server/middleware/dashboards/performance.yml
+++ b/server/middleware/dashboards/performance.yml
@@ -39,3 +39,19 @@ charts:
     name: "performance/fontsLoaded"
     query: "page:load-timing->median(context.timings.marks.fontsLoaded)->multiply(0.001)"
     datalabel: fontsLoaded
+  -
+    question: "What are browsers' average load times over the past 7 days?"
+    dashboardfeature: "frontpage"
+    queryname: "performance/averagepageload/offset"
+    name: "frontpage/performance/averagepageload/offset"
+    query: "page:load-timing->median(context.timings.offset.loadEventEnd)->filter(page.location.type=frontpage)->filter(device.browserName!=false)->group(device.browserName)->divide(1000)->sortAsc(device.browserName)"
+    printer: "BarChart"
+    datalabel: "Performance: Average page load time by browser"
+  -
+    question: "What are browsers' average load times over the past 7 days (from point page has downloaded)?"
+    dashboardfeature: "frontpage"
+    queryname: "performance/averagepageload/domloadingoffset"
+    name: "frontpage/performance/averagepageload/domloadingoffset"
+    query: "page:load-timing->median(context.timings.domLoadingOffset.loadEventEnd)->filter(page.location.type=frontpage)->filter(device.browserName!=false)->group(device.browserName)->divide(1000)->sortAsc(device.browserName)"
+    printer: "BarChart"
+    datalabel: "Performance: Average page load time by browser (graphs offset from the domLoading event)"


### PR DESCRIPTION
cc @wheresrhys @adambraimbridge 

![screen shot 2016-02-21 at 12 20 06](https://cloud.githubusercontent.com/assets/10484515/13202564/e7d17d40-d896-11e5-9dda-d87b4a452f40.png)