### PR TITLE
Add: Front page graphs

### DIFF
--- a/server/middleware/dashboards/frontpage.yml
+++ b/server/middleware/dashboards/frontpage.yml
@@ -4,6 +4,8 @@ title: Front page
 isprimary: true
 description: <dt>"Though it's cold and lonely in the deep dark night, I can see paradise by the dashboard light"</dt><dd>— Meat Loaf</dd>
 charts:
+
+  # PRE-PREPARED --------------------------------------------------
   -
     question: "Are daily front page member counts increasing?"
     dashboardfeature: "frontpage"
@@ -19,7 +21,7 @@ charts:
     query: "page:view->count()->filter(page.location.type=frontpage)"
     datalabel: "Total"
   -
-    question: "What percent of page views are frontpage"
+    question: "What percentage of page views are frontpage?"
     dashboardfeature: "frontpage"
     queryname: "views/proportion"
     name: "frontpage/views/proportion"
@@ -33,9 +35,519 @@ charts:
     query: "page:view->count(user.uuid)->filter(page.location.type=frontpage)"
     datalabel: "Members"
   -
-    question: "What percent of members visited the frontpage"
+    question: "What percentage of members visited the frontpage?"
     dashboardfeature: "frontpage"
     queryname: "visitors/proportion"
     name: "frontpage/visitors/proportion"
     query: "@pct(page:view->count(user.uuid)->filter(page.location.type=frontpage),page:view->count(user.uuid))"
     datalabel: "Member share"
+
+  # PERFORMANCE --------------------------------------------------
+  -
+    question: "What is the performance of the fonts loading?"
+    dashboardfeature: "frontpage"
+    queryname: "performance/fontload/marks"
+    name: "frontpage/performance/fontload/marks"
+    query: "page:load-timing->med(context.timings.marks.fontsLoaded)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)"
+    datalabel: "Performance: Fonts loaded"
+  -
+    question: "What is the performance of the fonts loading (from point page has downloaded)?"
+    dashboardfeature: "frontpage"
+    queryname: "performance/fontload/domloadingoffset"
+    name: "frontpage/performance/fontload/domloadingoffset"
+    query: "page:load-timing->med(context.timings.domLoadingOffset.fontsLoaded)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)"
+    datalabel: "Performance: Fonts loaded (offset from the domLoading event)"
+  -
+    question: "What is the performance of the page starting to render?"
+    dashboardfeature: "frontpage"
+    queryname: "performance/pagestartrender/custom"
+    name: "frontpage/performance/pagestartrender/custom"
+    query: "page:load-timing->med(context.timings.custom.firstPaint)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)"
+    datalabel: "Performance: Page starts to render"
+  -
+    question: "What is the performance of the page starting to render (from point page has downloaded)?"
+    dashboardfeature: "frontpage"
+    queryname: "performance/pagestartrender/domloadingoffset"
+    name: "frontpage/performance/pagestartrender/domloadingoffset"
+    query: "page:load-timing->med(context.timings.domLoadingOffset.firstPaint)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)"
+    datalabel: "Performance: Page starts to render (offset from the domLoading event)"
+  -
+    question: "What is the performance of the page loading?"
+    dashboardfeature: "frontpage"
+    queryname: "performance/pageload/offset"
+    name: "frontpage/performance/pageload/offset"
+    query: "page:load-timing->med(context.timings.offset.loadEventEnd)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)"
+    datalabel: "Performance: Page loaded"
+  -
+    question: "What is the performance of the page loading (from point page has downloaded)?"
+    dashboardfeature: "frontpage"
+    queryname: "performance/pageload/domloadingoffset"
+    name: "frontpage/performance/pageload/domloadingoffset"
+    query: "page:load-timing->med(context.timings.domLoadingOffset.loadEventEnd)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)"
+    datalabel: "Performance: Page loaded (offset from the domLoading event)"
+  -
+    question: "What are browsers' average load times over the past 7 days?"
+    dashboardfeature: "frontpage"
+    queryname: "performance/averagepageload/offset"
+    name: "frontpage/performance/averagepageload/offset"
+    query: "page:load-timing->med(context.timings.offset.loadEventEnd)->relTime(previous_7_days)->filter(page.location.type=frontpage)->filter(device.browserName!=false)->group(device.browserName)->divide(1000)->sortAsc(device.browserName)"
+    printer: "BarChart"
+    datalabel: "Performance: Average page load time by browser"
+  -
+    question: "What are browsers' average load times over the past 7 days (from point page has downloaded)?"
+    dashboardfeature: "frontpage"
+    queryname: "performance/averagepageload/domloadingoffset"
+    name: "frontpage/performance/averagepageload/domloadingoffset"
+    query: "page:load-timing->med(context.timings.domLoadingOffset.loadEventEnd)->relTime(previous_7_days)->filter(page.location.type=frontpage)->filter(device.browserName!=false)->group(device.browserName)->divide(1000)->sortAsc(device.browserName)"
+    printer: "BarChart"
+    datalabel: "Performance: Average page load time by browser (offset from the domLoading event)"
+  -
+    question: "What is the timing of page loading events (loadEventStart)?"
+    dashboardfeature: "frontpage"
+    queryname: "performance/pageloadingevents/loadeventstart/offset"
+    name: "frontpage/performance/pageloadingevents/loadeventstart/offset"
+    query: "page:load-timing->med(context.timings.offset.loadEventStart)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)"
+    datalabel: "Performance: Page loading events (loadEventStart)"
+  -
+    question: "What is the timing of page loading events (loadEventStart) (from point page has downloaded)?"
+    dashboardfeature: "frontpage"
+    queryname: "performance/pageloadingevents/loadeventstart/domloadingoffset"
+    name: "frontpage/performance/pageloadingevents/loadeventstart/domloadingoffset"
+    query: "page:load-timing->med(context.timings.domLoadingOffset.loadEventStart)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)"
+    datalabel: "Performance: Page loading events (loadEventStart) (offset from the domLoading event)"
+  -
+    question: "What is the timing of page loading events (domComplete)?"
+    dashboardfeature: "frontpage"
+    queryname: "performance/pageloadingevents/domcomplete/offset"
+    name: "frontpage/performance/pageloadingevents/domcomplete/offset"
+    query: "page:load-timing->med(context.timings.offset.domComplete)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)"
+    datalabel: "Performance: Page loading events (domComplete)"
+  -
+    question: "What is the timing of page loading events (domComplete) (from point page has downloaded)?"
+    dashboardfeature: "frontpage"
+    queryname: "performance/pageloadingevents/domcomplete/domloadingoffset"
+    name: "frontpage/performance/pageloadingevents/domcomplete/domloadingoffset"
+    query: "page:load-timing->med(context.timings.domLoadingOffset.domComplete)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)"
+    datalabel: "Performance: Page loading events (domComplete) (offset from the domLoading event)"
+  -
+    question: "What is the timing of page loading events (domContentLoadedEventStart)?"
+    dashboardfeature: "frontpage"
+    queryname: "performance/pageloadingevents/domcontentloadedeventstart/offset"
+    name: "frontpage/performance/pageloadingevents/domcontentloadedeventstart/offset"
+    query: "page:load-timing->med(context.timings.offset.domContentLoadedEventStart)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)"
+    datalabel: "Performance: Page loading events (domContentLoadedEventStart)"
+  -
+    question: "What is the timing of page loading events (domContentLoadedEventStart) (from point page has downloaded)?"
+    dashboardfeature: "frontpage"
+    queryname: "performance/pageloadingevents/domcontentloadedeventstart/domloadingoffset"
+    name: "frontpage/performance/pageloadingevents/domcontentloadedeventstart/domloadingoffset"
+    query: "page:load-timing->med(context.timings.domLoadingOffset.domContentLoadedEventStart)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)"
+    datalabel: "Performance: Page loading events (domContentLoadedEventStart) (offset from the domLoading event)"
+  -
+    question: "What is the timing of page loading events (domInteractive)?"
+    dashboardfeature: "frontpage"
+    queryname: "performance/pageloadingevents/dominteractive/offset"
+    name: "frontpage/performance/pageloadingevents/dominteractive/offset"
+    query: "page:load-timing->med(context.timings.offset.domInteractive)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)"
+    datalabel: "Performance: Page loading events (domInteractive)"
+  -
+    question: "What is the timing of page loading events (domInteractive) (from point page has downloaded)?"
+    dashboardfeature: "frontpage"
+    queryname: "performance/pageloadingevents/dominteractive/domloadingoffset"
+    name: "frontpage/performance/pageloadingevents/dominteractive/domloadingoffset"
+    query: "page:load-timing->med(context.timings.domLoadingOffset.domInteractive)->filter(page.location.type=frontpage)->filter(context.timings.offset.domInteractive)->relTime(previous_28_days)->interval(d)->divide(1000)"
+    datalabel: "Performance: Page loading events (domInteractive) (offset from the domLoading event)"
+
+  # SCROLL DEPTH --------------------------------------------------
+  # -
+  #   question: "What percentage of frontpage users are scrolling to each section?"
+  #   dashboardfeature: "frontpage"
+  #   queryname: "scrolldepth"
+  #   name: "frontpage/scrolldepth"
+  #   query: "page:scrolldepth->count()->filter(page.location.type=frontpage)->filter(context.domPath)->group(context.domPath, context.componentPos)"
+  #   datalabel: "Scroll depth"
+
+  # CTR (average percentage of clicks) --------------------------------------------------
+  -
+    question: "What percentage (average) of frontpage users are clicking through to other sections?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/percentage/all"
+    name: "frontpage/ctr/average/percentage/all"
+    query: "@pct(cta:click->count(user.uuid),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average percentage (all)"
+  -
+    question: "What percentage (average) of frontpage users are clicking through to other sections (from Header)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/percentage/header"
+    name: "frontpage/ctr/average/percentage/header"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~header),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average percentage (Header)"
+  -
+    question: "What percentage (average) of frontpage users are clicking through to other sections (from Top Stories)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/percentage/top-stories"
+    name: "frontpage/ctr/average/percentage/top-stories"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~top-stories),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average percentage (Top Stories)"
+  -
+    question: "What percentage (average) of frontpage users are clicking through to other sections (from FastFT)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/percentage/fastft"
+    name: "frontpage/ctr/average/percentage/fastft"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~fastft),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average percentage (FastFT)"
+  -
+    question: "What percentage (average) of frontpage users are clicking through to other sections (from Editors' Picks)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/percentage/editors-picks"
+    name: "frontpage/ctr/average/percentage/editors-picks"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~editors-picks),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average percentage (Editors' Picks)"
+  -
+    question: "What percentage (average) of frontpage users are clicking through to other sections (from Opinion)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/percentage/opinion"
+    name: "frontpage/ctr/average/percentage/opinion"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~opinion),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average percentage (Opinion)"
+  -
+    question: "What percentage (average) of frontpage users are clicking through to other sections (from myFT)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/percentage/myft"
+    name: "frontpage/ctr/average/percentage/myft"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~myft),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average percentage (myFT)"
+  -
+    question: "What percentage (average) of frontpage users are clicking through to other sections (from Most Popular)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/percentage/most-popular"
+    name: "frontpage/ctr/average/percentage/most-popular"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~most-popular),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average percentage (Most Popular)"
+  -
+    question: "What percentage (average) of frontpage users are clicking through to other sections (from Life & Arts)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/percentage/life-and-arts"
+    name: "frontpage/ctr/average/percentage/life-and-arts"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~life-and-arts),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average percentage (Life & Arts)"
+  -
+    question: "What percentage (average) of frontpage users are clicking through to other sections (from Markets)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/percentage/markets"
+    name: "frontpage/ctr/average/percentage/markets"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~markets),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average percentage (Markets)"
+  -
+    question: "What percentage (average) of frontpage users are clicking through to other sections (from Technology)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/percentage/technology"
+    name: "frontpage/ctr/average/percentage/technology"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~technology),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average percentage (Technology)"
+  -
+    question: "What percentage (average) of frontpage users are clicking through to other sections (from Video)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/percentage/video"
+    name: "frontpage/ctr/average/percentage/video"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~video),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average percentage (Video)"
+  
+  # CTR (average clicks) --------------------------------------------------
+  -
+    question: "How many clicks (average) are users making on the frontpage?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/clicks/all"
+    name: "frontpage/ctr/average/clicks/all"
+    query: "@ratio(cta:click->count(),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average clicks per user"
+  -
+    question: "How many clicks (average) are users making on the frontpage (from Header)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/clicks/header"
+    name: "frontpage/ctr/average/clicks/header"
+    query: "@ratio(cta:click->count()->filter(context.domPath~header),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average clicks per user (Header)"
+  -
+    question: "How many clicks (average) are users making on the frontpage (from Top Stories)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/clicks/top-stories"
+    name: "frontpage/ctr/average/clicks/top-stories"
+    query: "@ratio(cta:click->count()->filter(context.domPath~top-stories),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average clicks per user (Top Stories)"
+  -
+    question: "How many clicks (average) are users making on the frontpage (from FastFT)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/clicks/fastft"
+    name: "frontpage/ctr/average/clicks/fastft"
+    query: "@ratio(cta:click->count()->filter(context.domPath~fastft),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average clicks per user (FastFT)"
+  -
+    question: "How many clicks (average) are users making on the frontpage (from Editors' Picks)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/clicks/editors-picks"
+    name: "frontpage/ctr/average/clicks/editors-picks"
+    query: "@ratio(cta:click->count()->filter(context.domPath~editors-picks),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average clicks per user (Editors' Picks)"
+  -
+    question: "How many clicks (average) are users making on the frontpage (from Opinion)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/clicks/opinion"
+    name: "frontpage/ctr/average/clicks/opinion"
+    query: "@ratio(cta:click->count()->filter(context.domPath~opinion),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average clicks per user (Opinion)"
+  -
+    question: "How many clicks (average) are users making on the frontpage (from myFT)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/clicks/myft"
+    name: "frontpage/ctr/average/clicks/myft"
+    query: "@ratio(cta:click->count()->filter(context.domPath~myft),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average clicks per user (myFT)"
+  -
+    question: "How many clicks (average) are users making on the frontpage (from Most Popular)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/clicks/most-popular"
+    name: "frontpage/ctr/average/clicks/most-popular"
+    query: "@ratio(cta:click->count()->filter(context.domPath~most-popular),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average clicks per user (Most Popular)"
+  -
+    question: "How many clicks (average) are users making on the frontpage (from Life & Arts)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/clicks/life-and-arts"
+    name: "frontpage/ctr/average/clicks/life-and-arts"
+    query: "@ratio(cta:click->count()->filter(context.domPath~life-and-arts),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average clicks per user (Life & Arts)"
+  -
+    question: "How many clicks (average) are users making on the frontpage (from Markets)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/clicks/markets"
+    name: "frontpage/ctr/average/clicks/markets"
+    query: "@ratio(cta:click->count()->filter(context.domPath~markets),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average clicks per user (Markets)"
+  -
+    question: "How many clicks (average) are users making on the frontpage (from Technology)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/clicks/technology"
+    name: "frontpage/ctr/average/clicks/technology"
+    query: "@ratio(cta:click->count()->filter(context.domPath~technology),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average clicks per user (Technology)"
+  -
+    question: "How many clicks (average) are users making on the frontpage (from Video)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/clicks/video"
+    name: "frontpage/ctr/average/clicks/video"
+    query: "@ratio(cta:click->count()->filter(context.domPath~video),page:view->count(user.uuid))->filter(page.location.type=frontpage)->interval(d)->reduce(avg,timeframe)"
+    freeze: true
+    datalabel: "CTR average clicks per user (Video)"
+  # -
+  # **Average across 8 weeks (duration given in this instance)**
+    # question: "How many frontpage users are there averaged across 8 weeks?"
+    # dashboardfeature: "frontpage"
+    # queryname: "ctr/users"
+    # name: "frontpage/ctr/users"
+    # query: ""
+    # freeze: true
+    # datalabel: "CTR number of frontpage users"
+  # -
+  # **Average across 8 weeks (duration given in this instance)**
+    # question: "How many frontpage views are there averaged across 8 weeks?"
+    # dashboardfeature: "frontpage"
+    # queryname: "ctr/views"
+    # name: "frontpage/ctr/views"
+    # query: ""
+    # freeze: true
+    # datalabel: "CTR number of frontpage views"
+
+  # CTR (percentage) --------------------------------------------------
+  -
+    question: "What percentage of frontpage users are clicking through to other sections?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/duration/all"
+    name: "frontpage/ctr/average/duration/all"
+    query: "@pct(cta:click->count(user.uuid),page:view->count(user.uuid))->filter(page.location.type=frontpage)"
+    datalabel: "CTR average percentage duration"
+  -
+    question: "What percentage of frontpage users are clicking through to other sections (from Header)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/duration/header"
+    name: "frontpage/ctr/average/duration/header"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~header),page:view->count(user.uuid))->filter(page.location.type=frontpage)"
+    datalabel: "CTR average percentage duration (Header)"
+  -
+    question: "What percentage of frontpage users are clicking through to other sections (from Top Stories)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/duration/top-stories"
+    name: "frontpage/ctr/average/duration/top-stories"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~top-stories),page:view->count(user.uuid))->filter(page.location.type=frontpage)"
+    datalabel: "CTR average percentage duration (Top Stories)"
+  -
+    question: "What percentage of frontpage users are clicking through to other sections (from FastFT)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/duration/fastft"
+    name: "frontpage/ctr/average/duration/fastft"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~fastft),page:view->count(user.uuid))->filter(page.location.type=frontpage)"
+    datalabel: "CTR average percentage duration (FastFT)"
+  -
+    question: "What percentage of frontpage users are clicking through to other sections (from Editors' Picks)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/duration/editors-picks"
+    name: "frontpage/ctr/average/duration/editors-picks"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~editors-picks),page:view->count(user.uuid))->filter(page.location.type=frontpage)"
+    datalabel: "CTR average percentage duration (Editors' Picks)"
+  -
+    question: "What percentage of frontpage users are clicking through to other sections (from Opinion)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/duration/opinion"
+    name: "frontpage/ctr/average/duration/opinion"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~opinion),page:view->count(user.uuid))->filter(page.location.type=frontpage)"
+    datalabel: "CTR average percentage duration (Opinion)"
+  -
+    question: "What percentage of frontpage users are clicking through to other sections (from myFT)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/duration/myft"
+    name: "frontpage/ctr/average/duration/myft"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~myft),page:view->count(user.uuid))->filter(page.location.type=frontpage)"
+    datalabel: "CTR average percentage duration (myFT)"
+  -
+    question: "What percentage of frontpage users are clicking through to other sections (from Most Popular)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/duration/most-popular"
+    name: "frontpage/ctr/average/duration/most-popular"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~most-popular),page:view->count(user.uuid))->filter(page.location.type=frontpage)"
+    datalabel: "CTR average percentage duration (Most Popular)"
+  -
+    question: "What percentage of frontpage users are clicking through to other sections (from Life & Arts)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/duration/life-and-arts"
+    name: "frontpage/ctr/average/duration/life-and-arts"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~life-and-arts),page:view->count(user.uuid))->filter(page.location.type=frontpage)"
+    datalabel: "CTR average percentage duration (Life & Arts)"
+  -
+    question: "What percentage of frontpage users are clicking through to other sections (from Markets)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/duration/markets"
+    name: "frontpage/ctr/average/duration/markets"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~markets),page:view->count(user.uuid))->filter(page.location.type=frontpage)"
+    datalabel: "CTR average percentage duration (Markets)"
+  -
+    question: "What percentage of frontpage users are clicking through to other sections (from Technology)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/duration/technology"
+    name: "frontpage/ctr/average/duration/technology"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~technology),page:view->count(user.uuid))->filter(page.location.type=frontpage)"
+    datalabel: "CTR average percentage duration (Technology)"
+  -
+    question: "What percentage of frontpage users are clicking through to other sections (from Video)?"
+    dashboardfeature: "frontpage"
+    queryname: "ctr/average/duration/video"
+    name: "frontpage/ctr/average/duration/video"
+    query: "@pct(cta:click->count(user.uuid)->filter(context.domPath~video),page:view->count(user.uuid))->filter(page.location.type=frontpage)"
+    datalabel: "CTR average percentage duration (Video)"
+
+  # VOLUME/FREQUENCY/USERS --------------------------------------------------
+  # -
+  #   question: "How many articles do frontpage users read per week?"
+  #   dashboardfeature: "frontpage"
+  #   queryname: "volume/articlespw"
+  #   name: "frontpage/volume/articlespw"
+  #   query: ""
+  #   datalabel: "Volume: Articles read per week"
+  # -
+  #   question: "What percentage of frontpage users read at least 7 articles per week?"
+  #   dashboardfeature: "frontpage"
+  #   queryname: "volume/min7articlespw"
+  #   name: "frontpage/volume/min7articlespw"
+  #   query: ""
+  #   datalabel: "Volume: Minimum 7 articles read per week"
+  # -
+  #   question: "What percentage of frontpage users read at least 11 articles per week?"
+  #   dashboardfeature: "frontpage"
+  #   queryname: "volume/min11articlespw"
+  #   name: "frontpage/volume/min11articlespw"
+  #   query: ""
+  #   datalabel: "Volume: Minimum 11 articles read per week"
+  # -
+  #   question: "How many visits on average do frontpage users made to next.ft.com per week?"
+  #   dashboardfeature: "frontpage"
+  #   queryname: "frequency/visitspw"
+  #   name: "frontpage/frequency/visitspw"
+  #   query: ""
+  #   datalabel: "Frequency: Average visits per week"
+  # -
+  #   question: "How many frontpage users on next.ft.com per week?"
+  #   dashboardfeature: "frontpage"
+  #   queryname: "users/userspw"
+  #   name: "frontpage/users/userspw"
+  #   query: ""
+  #   datalabel: "Users: Number per week"
+
+  # VISITS --------------------------------------------------
+  -
+    question: "What percentage of yesterday's site-wide page views were frontpage views?"
+    dashboardfeature: "frontpage"
+    queryname: "visits/views/percent"
+    name: "frontpage/visits/views/percent"
+    query: "@pct(page:view->count()->filter(page.location.type=frontpage),page:view->count())->relTime(previous_1_days)"
+    freeze: true
+    datalabel: "Visits: Percentage of site-wide views"
+  -
+    question: "What was the total of yesterday's frontpage views?"
+    dashboardfeature: "frontpage"
+    queryname: "visits/views/total"
+    name: "frontpage/visits/views/total"
+    query: "page:view->count()->filter(page.location.type=frontpage)->relTime(previous_1_days)"
+    freeze: true
+    datalabel: "Visits: Total of frontpage views"
+  -
+    question: "What percentage of the past four weeks' site-wide page views were frontpage views?"
+    dashboardfeature: "frontpage"
+    queryname: "visits/views/duration"
+    name: "frontpage/visits/views/duration"
+    query: "@pct(page:view->count()->filter(page.location.type=frontpage),page:view->count())->relTime(previous_28_days)"
+    datalabel: "Visits: Number of views"
+  -
+    question: "What percentage of yesterday's site-wide visitors were frontpage visitors?"
+    dashboardfeature: "frontpage"
+    queryname: "visits/visitors/percent"
+    name: "frontpage/visits/visitors/percent"
+    query: "@pct(page:view->count(user.uuid)->filter(page.location.type=frontpage),page:view->count(user.uuid))->relTime(previous_1_days)"
+    freeze: true
+    datalabel: "Visits: Percentage of site-wide visitors"
+  -
+    question: "What was the total of yesterday's frontpage visitors?"
+    dashboardfeature: "frontpage"
+    queryname: "visits/visitors/total"
+    name: "frontpage/visits/visitors/total"
+    query: "page:view->count(user.uuid)->filter(page.location.type=frontpage)->relTime(previous_1_days)"
+    freeze: true
+    datalabel: "Visits: Total of frontpage visitors"
+  -
+    question: "What percentage of the past four weeks' site-wide visitors were frontpage visitors?"
+    dashboardfeature: "frontpage"
+    queryname: "visits/visitors/duration"
+    name: "frontpage/visits/visitors/duration"
+    query: "@pct(page:view->count(user.uuid)->filter(page.location.type=frontpage),page:view->count(user.uuid))->relTime(previous_28_days)"
+    datalabel: "Visits: Number of visitors"


### PR DESCRIPTION
cc @wheresrhys @adambraimbridge 

GENERAL
-------
- Units of measurement required as labels for graphs -> *beacon-v2 team to implement*
- In some graphs (Performance/CTR/Visits) data only correlates from 10 Feb 2016 onwards (some graphs have no data prior to 28 Jan 2016) -> *makes sense in terms of when data became available and then reliable*


PERFORMANCE
-----------
- Graphs will ultimately exist on 'performance' section of site with filters for each section (inc. frontpage) -> *frontpage team to migrate once filter implemented*
- Add switch so graphs offset from the domLoading event, i.e. from the point the page has downloaded (as per v1 frontpage performance graphs) -> *`subtract` function to be added by beacon-v2 team which will allow this*
- Add switch for connection type: cellular (2G, 3G, etc.), wifi, ethernet -> *filter to be added by beacon-v2 team*
- Post-retrieval filter: convert units to seconds units by dividing by 1000 (i.e. multiply by .001 (see above); `multiply` argument does not seem to work) - *divide being added by beacon-v2 team*

#### What is the performance of the fonts loading/page starting to render/page loading?
- Requires second Keen query for first two of above graphs to output metric note about browsers from which the data is collected (see [here](https://beacon.ft.com/graph/front-page/performance)) -> *substantial work required to implement this; separate query can acquire this data if needed*

#### What is the timing of page loading events?
- All four graphs (each w/ and w/out offset) must be grouped into single graph with overlapping lines -> *concatenating queries to be implemented by beacon-v2 team*


SCROLL DEPTH (WIP; not included in this PR)
------------
- Extra `data-trackable` property (i.e. scrollTarget) to be added to [frontpage code](https://github.com/Financial-Times/next-front-page/blob/0958c9ab4722e96cd1ce0d5c677a14b58b6eea07/client/components/scroll-depth/scroll-depth.js) so only valid sections are accounted for, i.e. ['top-stories', 'opinion', 'editors-picks', 'most-popular', 'technology', 'markets', 'life-and-arts', 'video']; remove `most-popular | alternate-source | Accountancy & tax advisory` / `most-popular | alternate-source | Food & beverages` / `top-stories-landscape` -> *frontpage team to implement*
- Add 'registered' as user type filter? -> *probably not required on top of anonymous and subscriber*
- Post-retrieval filters: Use top-stories amount as 100% basis for all other sections - can this be done in initial query given it is based on filtered data (can filter somehow be implemented at query stage)? -> *with additional `data-trackable` property in place this should be possible*


CTR
---
- Add component filter: All / Header / Top Stories / FastFT / Editor's Picks / Opinion / myFT / Most Popular / Life and Arts / Markets / Technology / Video -> *short-term solution: individual graph for each component / long-term solution: implement filter for components (by componentPos or domPath)*


VFU (VOLUME/FREQUENCY/USERS) (WIP; not included in this PR)
---
- ->  *substantial work reqd to perform these sorts of queries - check if these graphs used for weekly reporting before adding to priority to devise short-term solution; long-term solution may require shift to different data source (Redshift)*
- Requires multiple Keen queries
- Requires comparison of two sets of data
- Post-retrieval filters:
	- users who have viewed the front page at least once
	- acquire number of frontpage users for each week
	- acquire number of visits for week
	- acquire number of users who have viewed articles (less than 500 articles)
	- calculate mean volume
	- calculate mean frequency


VISITS
------
- Done!