### PR TITLE
Remove: Default timeframe & interval values

### DIFF
--- a/dashboards/frontpage.yml
+++ b/dashboards/frontpage.yml
@@ -426,12 +426,12 @@ charts:
     freeze: true
     datalabel: Total of frontpage views
   -
-    question: What percentage of the past four weeks' site-wide page views were frontpage views?
+    question: What percentage of site-wide page views were frontpage views?
     name: visits/views/period
     query: "@pct(
               page:view->count()->filter(page.location.type=frontpage),
               page:view->count()
-            )->relTime(previous_28_days)"
+            )"
     datalabel: Number of views
   -
     question: What percentage of yesterday's site-wide visitors were frontpage visitors?
@@ -449,96 +449,96 @@ charts:
     freeze: true
     datalabel: Total of frontpage visitors
   -
-    question: What percentage of the past four weeks' site-wide visitors were frontpage visitors?
+    question: What percentage of site-wide visitors were frontpage visitors?
     name: visits/visitors/period
     query: "@pct(
               page:view->count(user.uuid)->filter(page.location.type=frontpage),
               page:view->count(user.uuid)
-            )->relTime(previous_28_days)"
+            )"
     datalabel: Number of visitors
 
   # PERFORMANCE --------------------------------------------------
   -
     question: What is the performance of the fonts loading?
     name: performance/fontload/marks
-    query: page:load-timing->median(context.timings.marks.fontsLoaded)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)
+    query: page:load-timing->median(context.timings.marks.fontsLoaded)->filter(page.location.type=frontpage)->divide(1000)
     datalabel: Fonts loaded
   -
     question: What is the performance of the fonts loading (from point page has downloaded)?
     name: performance/fontload/domloadingoffset
-    query: page:load-timing->median(context.timings.domLoadingOffset.fontsLoaded)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)
+    query: page:load-timing->median(context.timings.domLoadingOffset.fontsLoaded)->filter(page.location.type=frontpage)->divide(1000)
     datalabel: Fonts loaded (offset from the domLoading event)
   -
     question: What is the performance of the page starting to render?
     name: performance/pagestartrender/custom
-    query: page:load-timing->median(context.timings.custom.firstPaint)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)
+    query: page:load-timing->median(context.timings.custom.firstPaint)->filter(page.location.type=frontpage)->divide(1000)
     datalabel: Page starts to render
   -
     question: What is the performance of the page starting to render (from point page has downloaded)?
     name: performance/pagestartrender/domloadingoffset
-    query: page:load-timing->median(context.timings.domLoadingOffset.firstPaint)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)
+    query: page:load-timing->median(context.timings.domLoadingOffset.firstPaint)->filter(page.location.type=frontpage)->divide(1000)
     datalabel: Page starts to render (offset from the domLoading event)
   -
     question: What is the performance of the page loading?
     name: performance/pageload/offset
-    query: page:load-timing->median(context.timings.offset.loadEventEnd)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)
+    query: page:load-timing->median(context.timings.offset.loadEventEnd)->filter(page.location.type=frontpage)->divide(1000)
     datalabel: Page loaded
   -
     question: What is the performance of the page loading (from point page has downloaded)?
     name: performance/pageload/domloadingoffset
-    query: page:load-timing->median(context.timings.domLoadingOffset.loadEventEnd)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)
+    query: page:load-timing->median(context.timings.domLoadingOffset.loadEventEnd)->filter(page.location.type=frontpage)->divide(1000)
     datalabel: Page loaded (offset from the domLoading event)
   -
-    question: What are browsers' average load times over the past 7 days?
+    question: What are browsers' average load times?
     name: performance/averagepageload/offset
-    query: page:load-timing->median(context.timings.offset.loadEventEnd)->relTime(previous_7_days)->filter(page.location.type=frontpage)->filter(device.browserName!=false)->group(device.browserName)->divide(1000)->sortAsc(device.browserName)
+    query: page:load-timing->median(context.timings.offset.loadEventEnd)->filter(page.location.type=frontpage)->filter(device.browserName!=false)->group(device.browserName)->divide(1000)->sortAsc(device.browserName)
     printer: BarChart
     datalabel: Average page load time by browser
   -
-    question: What are browsers' average load times over the past 7 days (from point page has downloaded)?
+    question: What are browsers' average load times (from point page has downloaded)?
     name: performance/averagepageload/domloadingoffset
-    query: page:load-timing->median(context.timings.domLoadingOffset.loadEventEnd)->relTime(previous_7_days)->filter(page.location.type=frontpage)->filter(device.browserName!=false)->group(device.browserName)->divide(1000)->sortAsc(device.browserName)
+    query: page:load-timing->median(context.timings.domLoadingOffset.loadEventEnd)->filter(page.location.type=frontpage)->filter(device.browserName!=false)->group(device.browserName)->divide(1000)->sortAsc(device.browserName)
     printer: BarChart
     datalabel: Average page load time by browser (offset from the domLoading event)
   -
     question: What is the timing of page loading events (loadEventStart)?
     name: performance/pageloadingevents/loadeventstart/offset
-    query: page:load-timing->median(context.timings.offset.loadEventStart)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)
+    query: page:load-timing->median(context.timings.offset.loadEventStart)->filter(page.location.type=frontpage)->divide(1000)
     datalabel: Page loading events (loadEventStart)
   -
     question: What is the timing of page loading events (loadEventStart) (from point page has downloaded)?
     name: performance/pageloadingevents/loadeventstart/domloadingoffset
-    query: page:load-timing->median(context.timings.domLoadingOffset.loadEventStart)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)
+    query: page:load-timing->median(context.timings.domLoadingOffset.loadEventStart)->filter(page.location.type=frontpage)->divide(1000)
     datalabel: Page loading events (loadEventStart) (offset from the domLoading event)
   -
     question: What is the timing of page loading events (domComplete)?
     name: performance/pageloadingevents/domcomplete/offset
-    query: page:load-timing->median(context.timings.offset.domComplete)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)
+    query: page:load-timing->median(context.timings.offset.domComplete)->filter(page.location.type=frontpage)->divide(1000)
     datalabel: Page loading events (domComplete)
   -
     question: What is the timing of page loading events (domComplete) (from point page has downloaded)?
     name: performance/pageloadingevents/domcomplete/domloadingoffset
-    query: page:load-timing->median(context.timings.domLoadingOffset.domComplete)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)
+    query: page:load-timing->median(context.timings.domLoadingOffset.domComplete)->filter(page.location.type=frontpage)->divide(1000)
     datalabel: Page loading events (domComplete) (offset from the domLoading event)
   -
     question: What is the timing of page loading events (domContentLoadedEventStart)?
     name: performance/pageloadingevents/domcontentloadedeventstart/offset
-    query: page:load-timing->median(context.timings.offset.domContentLoadedEventStart)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)
+    query: page:load-timing->median(context.timings.offset.domContentLoadedEventStart)->filter(page.location.type=frontpage)->divide(1000)
     datalabel: Page loading events (domContentLoadedEventStart)
   -
     question: What is the timing of page loading events (domContentLoadedEventStart) (from point page has downloaded)?
     name: performance/pageloadingevents/domcontentloadedeventstart/domloadingoffset
-    query: page:load-timing->median(context.timings.domLoadingOffset.domContentLoadedEventStart)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)
+    query: page:load-timing->median(context.timings.domLoadingOffset.domContentLoadedEventStart)->filter(page.location.type=frontpage)->divide(1000)
     datalabel: Page loading events (domContentLoadedEventStart) (offset from the domLoading event)
   -
     question: What is the timing of page loading events (domInteractive)?
     name: performance/pageloadingevents/dominteractive/offset
-    query: page:load-timing->median(context.timings.offset.domInteractive)->filter(page.location.type=frontpage)->relTime(previous_28_days)->interval(d)->divide(1000)
+    query: page:load-timing->median(context.timings.offset.domInteractive)->filter(page.location.type=frontpage)->divide(1000)
     datalabel: Page loading events (domInteractive)
   -
     question: What is the timing of page loading events (domInteractive) (from point page has downloaded)?
     name: performance/pageloadingevents/dominteractive/domloadingoffset
-    query: page:load-timing->median(context.timings.domLoadingOffset.domInteractive)->filter(page.location.type=frontpage)->filter(context.timings.offset.domInteractive)->relTime(previous_28_days)->interval(d)->divide(1000)
+    query: page:load-timing->median(context.timings.domLoadingOffset.domInteractive)->filter(page.location.type=frontpage)->filter(context.timings.offset.domInteractive)->divide(1000)
     datalabel: Page loading events (domInteractive) (offset from the domLoading event)
 
   # BROWSER USAGE --------------------------------------------------


### PR DESCRIPTION
cc @adambraimbridge @wheresrhys 

Seems `@pct` and `@ratio` queries still require `->interval(d)` applied else: `Error: No data points returned for this query`, so have left those instances in.

Have also kept in a `relTime` argument for some graphs that display yesterday's frontpage views and visitors data (in both # and % forms), which seem specific enough to warrant it.