### PR TITLE
Remove Reltime and Interval from graphs

### DIFF
--- a/dashboards/article.yml
+++ b/dashboards/article.yml
@@ -39,13 +39,13 @@ charts:
   -
     question: How many article views come from other articles?
     name: article-views/article-referrer
-    query: "@pct(page:view->count()->filter(page.location.type=article)->filter(page.referrer.type=article),page:view->count()->filter(page.location.type=article))->relTime(previous_14_days)->interval(d)"
+    query: "@pct(page:view->count()->filter(page.location.type=article)->filter(page.referrer.type=article),page:view->count()->filter(page.location.type=article))"
     datalabel: Article views referred by articles %
     colspan: 12 L4
   -
     question: What's the CTR on articles by link type?
     name: article-elements/ctr
-    query: "@concat(@pct(cta:click->count()->filter(context.domPath~headline-link--topic),page:view->count()),@pct(cta:click->count()->filter(context.domPath~headline-link--topic--moreRecent),page:view->count()),@pct(cta:click->count()->filter(context.domPath~suggested-article),page:view->count()),@pct(cta:click->count()->filter(context.domPath~link-article-headline),page:view->count()),@pct(cta:click->count()->filter(context.domPath~link-headline),page:view->count()))->filter(page.location.type=article)->interval(d)->relTime(previous_14_days)->relabel(_headings,Read Next,Read Latest,Recommended,More Ons,Promoboxes)"
+    query: "@concat(@pct(cta:click->count()->filter(context.domPath~headline-link--topic),page:view->count()),@pct(cta:click->count()->filter(context.domPath~headline-link--topic--moreRecent),page:view->count()),@pct(cta:click->count()->filter(context.domPath~suggested-article),page:view->count()),@pct(cta:click->count()->filter(context.domPath~link-article-headline),page:view->count()),@pct(cta:click->count()->filter(context.domPath~link-headline),page:view->count()))->filter(page.location.type=article)->relabel(_headings,Read Next,Read Latest,Recommended,More Ons,Promoboxes)"
     datalabel: CTR by link type
     break: true
     colspan: 12

--- a/dashboards/giftandemail
+++ b/dashboards/giftandemail
@@ -7,7 +7,7 @@ charts:
   -
     question: What's the conversion on Gift article from expand to send to open?
     name: sharing/giftflow
-    query: "@concat(@sum(email-article:TOGGLE_OPEN_TOP,email-article:TOGGLE_OPEN_BOTTOM),email-article:SEND_SUCCESS->filter(context.state.isGift?true),page:interaction->filter(campaign.tools.shareType=gift))->count()->relTime(previous_14_days)->interval(d)->relabel(_headings,Expanded UI,Sent Gift,Opened Article on Next)"
+    query: "@concat(@sum(email-article:TOGGLE_OPEN_TOP,email-article:TOGGLE_OPEN_BOTTOM),email-article:SEND_SUCCESS->filter(context.state.isGift?true),page:interaction->filter(campaign.tools.shareType=gift))->count()->relabel(_headings,Expanded UI,Sent Gift,Opened Article on Next)"
     datalabel: Gift Article conversion
     colspan: 8
   -
@@ -26,19 +26,19 @@ charts:
   -
     question: How many gifted/shared emails has the backend sent?
     name: sharing/giftandshare
-    query: "email:delivery->count()->filter(context.product?gift-article,next-send-article-by-email)->group(context.product)->relTime(previous_14_days)->interval(d)"
+    query: "email:delivery->count()->filter(context.product?gift-article,next-send-article-by-email)->group(context.product)"
     datalabel: Emails delivered
     colspan: 12 L4
   -
     question: What's the open-rate for gifted/shared articles?
     name: sharing/openrate
-    query: "@concat(@pct(email:open->count()->filter(context.product=next-send-article-by-email),email:delivery->count()->filter(context.product=next-send-article-by-email)),@pct(email:open->count()->filter(context.product=gift-article),email:delivery->count()->filter(context.product=gift-article)))->relTime(this_14_days)->interval(d)"
+    query: "@concat(@pct(email:open->count()->filter(context.product=next-send-article-by-email),email:delivery->count()->filter(context.product=next-send-article-by-email)),@pct(email:open->count()->filter(context.product=gift-article),email:delivery->count()->filter(context.product=gift-article)))"
     datalabel: Article views by referrer
     colspan: 12 L4
   -
     question: How many article views were from gifted/shared emails?
     name: sharing/pagereferrals
-    query: "page:interaction->count()->filter(campaign.tools.shareType)->group(campaign.tools.shareType)->relTime(this_14_days)->interval(d)"
+    query: "page:interaction->count()->filter(campaign.tools.shareType)->group(campaign.tools.shareType)"
     datalabel: Article views by referrer
     colspan: 12 L4
   -

--- a/dashboards/streams.yml
+++ b/dashboards/streams.yml
@@ -37,7 +37,7 @@ charts:
   -
     question: What's the CTR from the Video Component on Streams?
     name: videoCTR
-    query: "@sum(cta:click->filter(context.domPath~video-highlights),cta:click->filter(context.domPath~related item))->count()->filter(page.location.type=stream)->relTime(previous_14_days)->interval(d)->print(LineChart)"
+    query: "@sum(cta:click->filter(context.domPath~video-highlights),cta:click->filter(context.domPath~related item))->count()->filter(page.location.type=stream)->print(LineChart)"
     datalabel: CTR on Video
   -
     question: What's the CTR of related topics and in the news in Streams?


### PR DESCRIPTION
To allow beacon time selector to work properly across Article / Gift / Stream dashboards.