### PR TITLE
Temporary revert of the range slider on the data/extract page.

### DIFF
--- a/views/extract.html
+++ b/views/extract.html
@@ -26,7 +26,10 @@
 		</div>
 		<div data-o-grid-colspan="8">
 			<h4>
-				<label>{{>range}}</label>
+				<label>
+					Extract <input id="extract__numberOfEvents-range" type="range" min="100" max="10000" value="100" step="100" oninput="outputUpdate(value)"> <output for="extract__numberOfEvents-range" class="extract__numberOfEvents">100</output> events.
+				</label>
+				<button type="button" class="o-buttons extract__submit">Loading ...</button>
 			</h4>
 			<div class="extract__output">
 				<table class="o-table o-table--row-stripes o-table--compact" data-o-component="o-table">


### PR DESCRIPTION
cc @lc512k Just an emergency tweak so that we can extract data for the NSS team.

e.g. https://beacon.ft.com/data/extract/feedback:submit/context.comment,context.reportSomething,time.timestamp,user.geo.ftRegion