### PR TITLE
Added ability to download extracted data as CSV

### DIFF
--- a/client/pages/extract.js
+++ b/client/pages/extract.js
@@ -1,4 +1,4 @@
-/* global activeEventCollection, KEEN_PROJECT_ID, KEEN_READ_KEY */
+/* global $, activeEventCollection, KEEN_PROJECT_ID, KEEN_READ_KEY */
 
 'use strict';
 
@@ -123,7 +123,6 @@ function prepareDownloadCSV(response){
 	// Output data
 	csv.stringify(flattened, (err, data) => {
 		if (err) {
-			res.status(503).body(err);
 			return;
 		}
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "body-parser": "^1.15.2",
     "botkit": "0.0.5",
     "cookie-parser": "^1.3.5",
-    "csv": "^0.4.4",
+    "csv": "^0.4.6",
     "denodeify": "^1.2.1",
     "didyoumean": "^1.2.1",
     "fetchres": "^1.5.1",

--- a/views/extract.html
+++ b/views/extract.html
@@ -30,6 +30,7 @@
 					Extract <input id="extract__numberOfEvents-range" type="range" min="100" max="10000" value="100" step="100" oninput="outputUpdate(value)"> <output for="extract__numberOfEvents-range" class="extract__numberOfEvents">100</output> events.
 				</label>
 				<button type="button" class="o-buttons extract__submit">Loading ...</button>
+				<a class="o-buttons extract__download hidden">Download a CSV copy</a>
 			</h4>
 			<div class="extract__output">
 				<table class="o-table o-table--row-stripes o-table--compact" data-o-component="o-table">

--- a/views/partials/primary-navigation.html
+++ b/views/partials/primary-navigation.html
@@ -4,6 +4,7 @@
 		<li data-priority="70" class="internal-tool"><a href="/data/explorer">Data explorer</a></li>
 		<li data-priority="1" class="o-hierarchical-nav__parent"><a>☰</a>
 			<ul data-o-hierarchical-nav-level="2">
+				<li><a title="Extract" href="/data/extract"> Extract data </a></li>
 				<li class="o-hierarchical-nav__parent"><a>Custom dashboards <i></i></a>
 					<ul data-o-hierarchical-nav-level="3">
 						{{#each customDashboards}}{{#if dashboardfeature}}


### PR DESCRIPTION
cc @lc512k this might be helpful in our efforts to reduce/eliminate any need for the "[Next Satisfaction Tracker](https://docs.google.com/spreadsheets/d/1eUgKwDbDCSKdKlrSWY9Ib1XVW-BJVdtY3K5kMHmvM-I/edit#gid=0)" spreadsheet.

Below: New "Download a CSV copy" button
![image](https://cloud.githubusercontent.com/assets/224547/16951834/98a200da-4dbe-11e6-9e55-3bc230251e2b.png)

Below: The downloaded CSV file can be uploaded to Google Drive, or opened in whatever spreadsheet app is preferred.
![image](https://cloud.githubusercontent.com/assets/224547/16951821/8d9d4fa0-4dbe-11e6-9e36-089b09b531b5.png)



